### PR TITLE
Mark the application as EOL

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,27 @@
+From c1135159210b4326618fa8b60f324f393aeae036 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Thu, 20 Jun 2024 13:08:07 +0300
+Subject: [PATCH] fix appdata papercuts
+
+---
+ data/io.github.lemmygtk.lemoa.metainfo.xml.in | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/data/io.github.lemmygtk.lemoa.metainfo.xml.in b/data/io.github.lemmygtk.lemoa.metainfo.xml.in
+index 2cf7729..214898c 100644
+--- a/data/io.github.lemmygtk.lemoa.metainfo.xml.in
++++ b/data/io.github.lemmygtk.lemoa.metainfo.xml.in
+@@ -116,10 +116,5 @@
+   <developer_name>Bnyro</developer_name>
+   <update_contact>bnyro@tutanota.com</update_contact>
+   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
+-  <platform>GTK 4</platform>
+ 
+-  <custom>
+-    <value key="Purism::form_factor">workstation</value>
+-    <value key="Purism::form_factor">mobile</value>
+-  </custom>
+ </component>
+--
+libgit2 1.7.2
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+	"end-of-life": "This application is no longer maintained."
+}

--- a/io.github.lemmygtk.lemoa.json
+++ b/io.github.lemmygtk.lemoa.json
@@ -40,6 +40,10 @@
                     "type": "archive",
                     "url": "https://github.com/lemmygtk/lemoa/releases/download/v0.5.1/lemoa-0.5.1.tar.xz",
                     "sha256": "8943d0f181104c3d2e0c3e81238422462efa94d8757f819d1ad757378f6ee15f"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
Mark the application as EOL

> This repository has been archived by the owner on Feb 12, 2024. It is now read-only. 

Source: https://github.com/lemmygtk/lemoa

Fixes: https://github.com/flathub/io.github.lemmygtk.lemoa/issues/7